### PR TITLE
feat(product_commingle): product comingling and co

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,13 +55,7 @@ jobs:
         run: oca_install_addons
       - name: Check licenses
         run: manifestoo -d . check-licenses
-      - name: Check development status
-        run: manifestoo -d . check-dev-status --default-dev-status=Beta
       - name: Initialize test db
         run: oca_init_test_database
       - name: Run tests
         run: oca_run_tests
-      - uses: codecov/codecov-action@v1
-      - name: Update .pot files
-        run: oca_export_and_push_pot https://x-access-token:${{ secrets.GIT_PUSH_TOKEN }}@github.com/${{ github.repository }}
-        if: ${{ matrix.makepot == 'true' && github.event_name == 'push' && github.repository_owner == 'OCA' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,8 +53,6 @@ jobs:
           persist-credentials: false
       - name: Install addons and dependencies
         run: oca_install_addons
-      - name: Check licenses
-        run: manifestoo -d . check-licenses
       - name: Initialize test db
         run: oca_init_test_database
       - name: Run tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
           - --remove-duplicate-keys
           - --remove-unused-variables
   - repo: https://github.com/psf/black
-    rev: 21.9b0
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-prettier

--- a/.pylintrc
+++ b/.pylintrc
@@ -4,7 +4,7 @@ score=n
 
 [ODOOLINT]
 readme_template_url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
-manifest_required_authors=Glodo
+manifest_required_authors=Glo Networks
 manifest_required_keys=license
 manifest_deprecated_keys=description,active
 license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3

--- a/.pylintrc-mandatory
+++ b/.pylintrc-mandatory
@@ -4,7 +4,7 @@ score=n
 
 [ODOOLINT]
 readme_template_url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
-manifest_required_authors=Glodo
+manifest_required_authors=Glo Networks
 manifest_required_keys=license
 manifest_deprecated_keys=description,active
 license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3

--- a/product_commingle/README.rst
+++ b/product_commingle/README.rst
@@ -1,0 +1,30 @@
+=================
+product_commingle
+=================
+
+Provides primitives for the commingling of products.
+
+:warning: By itself this module does nothing. `product_commingle_mrp` and `product_commingle_stock` are the ultimate workhorses.
+
+Supports the scenario where you have a product which is a composite of other products
+(but not a kit).
+
+This module is built to supersede `mrp_phantom_equiv` for the following reasons:
+
+1. Allows for installations without `mrp` by making it optional through `product_commingle_mrp`.
+2. Under 13.0+ changes with the way BoMs are exploded made `mrp_phantom_equiv` horrifically slow and problematic.
+
+
+Example scenario
+----------------
+
+* Chair A is the item sold to a customer
+* There are 2 different suppliers for that product - ChairB (supplier 1) and ChairC (supplier 2), which are considered to be "close enough" to be considered as the same product.
+* ChairB and ChairC are not simply rolled into ChairA (i.e. setting ChairA with 2 distinct suppliers) in order to aid tracking of supply issues, returns, etc.
+
+Usage
+-----
+
+1. Create a product and set "Is Commingled?"
+2. On the commingled tab, add the commingled products
+

--- a/product_commingle/__init__.py
+++ b/product_commingle/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/product_commingle/__manifest__.py
+++ b/product_commingle/__manifest__.py
@@ -1,0 +1,16 @@
+{
+    "name": "product_commingle",
+    "summary": "Product Commingling",
+    "author": "Glo Networks",
+    "website": "https://github.com/OCA/stock-delivery",
+    "category": "Uncategorized",
+    "version": "15.0.1.0.0",
+    "depends": ["product"],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/product_commingled.xml",
+        "views/product_template.xml",
+    ],
+    "demo": [],
+    "license": "AGPL-3",
+}

--- a/product_commingle/models/__init__.py
+++ b/product_commingle/models/__init__.py
@@ -1,0 +1,3 @@
+from . import product_commingled
+from . import product_template
+from . import product_product

--- a/product_commingle/models/product_commingled.py
+++ b/product_commingle/models/product_commingled.py
@@ -1,0 +1,56 @@
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class ProductCommingled(models.Model):
+    _name = "product.commingled"
+    _description = "Product Commingled Line"
+    _order = "sequence asc"
+
+    sequence = fields.Integer(default=10)
+    parent_product_id = fields.Many2one("product.product", required=True)
+    product_id = fields.Many2one("product.product", required=True)
+
+    _sql_constraints = [
+        (
+            "product_uniq",
+            "unique(parent_product_id, product_id)",
+            "Product can not be duplicated",
+        ),
+    ]
+
+    @api.constrains("product_id")
+    def _check_uom_category(self):
+        for line in self:
+            parent_product = line.parent_product_id
+            lines = line
+            while lines:
+                if (
+                    parent_product.uom_id.category_id
+                    != lines.product_id.uom_id.category_id
+                ):
+                    raise ValidationError(
+                        _(
+                            "You cannot mix and match commingled products with"
+                            " different UoM categories!\nParent: %(parent)s,"
+                            " Child: %(child)s"
+                        )
+                        % {"parent": parent_product, "child": lines.product_id}
+                    )
+                lines = lines.mapped("product_id.commingled_ids")
+
+    @api.constrains("product_id")
+    def _check_recursion(self):
+        for line in self:
+            parent_product = line.parent_product_id
+            lines = line
+            while lines:
+                if parent_product in lines.mapped("product_id"):
+                    raise ValidationError(
+                        _(
+                            "You cannot create recursive commingled"
+                            " products!\nProduct: %(product)s"
+                        )
+                        % {"product": parent_product}
+                    )
+                lines = lines.mapped("product_id.commingled_ids")

--- a/product_commingle/models/product_product.py
+++ b/product_commingle/models/product_product.py
@@ -1,0 +1,18 @@
+from odoo import fields, models
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    commingled_ids = fields.One2many(
+        "product.commingled",
+        "parent_product_id",
+        "Commingled Products",
+        copy=False,
+    )
+
+    used_in_commingled_ids = fields.One2many(
+        "product.commingled",
+        "product_id",
+        copy=False,
+    )

--- a/product_commingle/models/product_template.py
+++ b/product_commingle/models/product_template.py
@@ -1,0 +1,56 @@
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    commingled_ok = fields.Boolean(
+        "Is Commingled?",
+    )
+    commingled_ids = fields.One2many(
+        "product.commingled",
+        compute="_compute_commingled",
+        inverse="_inverse_commingled",
+    )
+    used_in_commingled_ids = fields.One2many(
+        related="product_variant_ids.used_in_commingled_ids",
+    )
+
+    @api.depends("product_variant_ids", "product_variant_ids.commingled_ids")
+    def _compute_commingled(self):
+        for p in self:
+            if len(p.product_variant_ids) == 1:
+                p.commingled_ids = p.product_variant_ids.commingled_ids
+            else:
+                p.commingled_ids = False
+
+    def _inverse_commingled(self):
+        for p in self:
+            if len(p.product_variant_ids) == 1:
+                p.product_variant_ids.commingled_ids = p.commingled_ids
+
+    @api.constrains("company_id", "product_variant_ids")
+    def _check_commingled_company(self):
+        # Ensure that the commingled products are all in the same company
+        for record in self:
+            for line in record.commingled_ids:
+                if (
+                    line.product_id.company_id and record.company_id
+                ) and line.product_id.company_id != record.company_id:
+                    raise ValidationError(
+                        _(
+                            "Commingled products must be in the company same as"
+                            " the parent product"
+                        )
+                    )
+            for line in record.used_in_commingled_ids:
+                if (
+                    line.product_id.company_id and record.company_id
+                ) and line.parent_product_id.company_id != record.company_id:
+                    raise ValidationError(
+                        _(
+                            "Commingled products must be in the company same as"
+                            " the parent product"
+                        )
+                    )

--- a/product_commingle/security/ir.model.access.csv
+++ b/product_commingle/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_product_commingled_user,access_product_commingled_user,model_product_commingled,base.group_user,1,0,0,0
+access_product_commingled_system,access_product_commingled_system,model_product_commingled,base.group_system,1,1,1,1

--- a/product_commingle/tests/__init__.py
+++ b/product_commingle/tests/__init__.py
@@ -1,0 +1,2 @@
+from . import common
+from . import test_commingle

--- a/product_commingle/tests/common.py
+++ b/product_commingle/tests/common.py
@@ -1,0 +1,44 @@
+from odoo.tests.common import TransactionCase
+
+
+class CommonCommingleCase(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.product_bolta = cls.env["product.product"].create(
+            {
+                "name": "Bolt A",
+            }
+        )
+
+        cls.product_boltb = cls.env["product.product"].create(
+            {
+                "name": "Bolt B",
+            }
+        )
+
+        cls.product_bolt_equiv = cls.env["product.product"].create(
+            {
+                "name": "Bolt Equiv",
+                "commingled_ok": True,
+                "commingled_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "sequence": 1,
+                            "product_id": cls.product_bolta.id,
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "sequence": 2,
+                            "product_id": cls.product_boltb.id,
+                        },
+                    ),
+                ],
+            }
+        )

--- a/product_commingle/tests/test_commingle.py
+++ b/product_commingle/tests/test_commingle.py
@@ -1,0 +1,15 @@
+from odoo.exceptions import ValidationError
+
+from odoo.addons.product_commingle.tests.common import CommonCommingleCase
+
+
+class TestCommingle(CommonCommingleCase):
+    def test_recursive(self):
+        with self.assertRaises(ValidationError):
+            self.product_bolt_equiv.write(
+                {
+                    "commingled_ids": [
+                        (0, 0, {"product_id": self.product_bolt_equiv.id})
+                    ],
+                }
+            )

--- a/product_commingle/views/product_commingled.xml
+++ b/product_commingle/views/product_commingled.xml
@@ -1,0 +1,24 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<odoo>
+    <record id="view_product_commingled_form" model="ir.ui.view">
+        <field name="name">view_product_commingled_form</field>
+        <field name="model">product.commingled</field>
+        <field name="arch" type="xml">
+            <form string="Commingled Products">
+                <group>
+                    <field name="product_id" />
+                </group>
+            </form>
+        </field>
+    </record>
+    <record id="view_product_commingled_tree" model="ir.ui.view">
+        <field name="name">view_product_commingled_tree</field>
+        <field name="model">product.commingled</field>
+        <field name="arch" type="xml">
+            <tree editable="bottom">
+                <field name="sequence" widget="handle" />
+                <field name="product_id" widget="many2one" />
+            </tree>
+        </field>
+    </record>
+</odoo>

--- a/product_commingle/views/product_template.xml
+++ b/product_commingle/views/product_template.xml
@@ -1,0 +1,37 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<odoo>
+    <record id="product_template_form_view" model="ir.ui.view">
+        <field name="name">product_template_form_view</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view" />
+        <field name="arch" type="xml">
+            <xpath expr="//div[@name='options']" position="inside">
+                <div>
+                    <field name="commingled_ok" />
+                    <label for="commingled_ok" />
+                </div>
+            </xpath>
+            <xpath expr="//notebook/page[@name='general_information']" position="after">
+                <page
+                    name="page_commingled"
+                    string="Commingled"
+                    attrs="{'invisible': [('commingled_ok', '=', False)]}"
+                >
+                   <field name="commingled_ids" />
+                </page>
+            </xpath>
+        </field>
+    </record>
+    <record model="ir.ui.view" id="product_template_only_form_view">
+        <field name="name">product_template_only_form_view</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_only_form_view" />
+        <field name="arch" type="xml">
+            <page name="page_commingled" position="attributes">
+                <attribute
+                    name="attrs"
+                >{'invisible': ['|', ('product_variant_count', '&gt;', 1), ('commingled_ok', '=', False)]}</attribute>
+            </page>
+        </field>
+    </record>
+</odoo>

--- a/product_commingle_mrp/README.rst
+++ b/product_commingle_mrp/README.rst
@@ -1,0 +1,7 @@
+=====================
+product_commingle_mrp
+=====================
+
+Integrates product_commingle and mrp to allow commingled products inside of
+a BoM.
+

--- a/product_commingle_mrp/__init__.py
+++ b/product_commingle_mrp/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/product_commingle_mrp/__manifest__.py
+++ b/product_commingle_mrp/__manifest__.py
@@ -1,0 +1,11 @@
+{
+    "name": "product_commingle_mrp",
+    "summary": """product_commingle <-> mrp glue module""",
+    "author": "Glo Networks",
+    "website": "https://github.com/OCA/stock-delivery",
+    "category": "Uncategorized",
+    "version": "15.0.1.0.0",
+    "depends": ["product_commingle", "mrp"],
+    "data": [],
+    "license": "AGPL-3",
+}

--- a/product_commingle_mrp/models/__init__.py
+++ b/product_commingle_mrp/models/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_move

--- a/product_commingle_mrp/models/stock_move.py
+++ b/product_commingle_mrp/models/stock_move.py
@@ -1,0 +1,30 @@
+from odoo import models
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    def _skip_action_commingled(self):
+        res = super()._skip_action_commingled()
+
+        return res or (
+            self.production_id and self.production_id.product_id == self.product_id
+        )
+
+    def _action_commingled(self):
+        before_commingling = set(self.ids)
+        # support phantom kits within commingled
+        moves = super()._action_commingled()
+        if before_commingling != set(moves.ids):
+            moves = moves.action_explode()
+        return moves
+
+    def action_explode(self):
+        before_explosion = set(self.ids)
+        moves = super().action_explode()
+        if before_explosion != set(moves.ids) and moves.filtered(
+            lambda m: not m._skip_action_commingled()
+        ):
+            # support commingled within phantom kits
+            moves = moves._action_commingled()
+        return moves

--- a/product_commingle_mrp/tests/__init__.py
+++ b/product_commingle_mrp/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_mrp

--- a/product_commingle_mrp/tests/test_mrp.py
+++ b/product_commingle_mrp/tests/test_mrp.py
@@ -1,0 +1,75 @@
+from odoo.tests import tagged
+
+from odoo.addons.product_commingle.tests.common import CommonCommingleCase
+
+
+@tagged("post_install", "-at_install")
+class TestMrp(CommonCommingleCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.product_bolta.type = "product"
+        cls.product_boltb.type = "product"
+        cls.product_bolt_equiv.type = "product"
+        cls.product_bolt_equiv.commingled_policy = "strict"
+
+        cls.partner_id = cls.env["res.partner"].create({"name": "Partner A"})
+        cls.stock_location = cls.env.ref("stock.stock_location_stock")
+        cls.customer_location = cls.env.ref("stock.stock_location_customers")
+
+        cls.product_bolt_kit = cls.env["product.product"].create(
+            {
+                "name": "Bolt Kit",
+                "type": "product",
+            }
+        )
+
+        cls.bom_equiv_kit = cls.env["mrp.bom"].create(
+            {
+                "product_tmpl_id": cls.product_bolt_kit.product_tmpl_id.id,
+                "product_qty": 1.0,
+                "type": "phantom",
+                "bom_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": cls.product_bolt_equiv.id,
+                            "product_qty": 1.0,
+                            "product_uom_id": cls.product_bolt_equiv.uom_id.id,
+                        },
+                    ),
+                ],
+            }
+        )
+
+    def test_simple_stock_move_nested_inside_kit(self):
+        picking_id = self.env["stock.picking"].create(
+            {
+                "location_id": self.stock_location.id,
+                "location_dest_id": self.customer_location.id,
+                "picking_type_id": self.env.ref("stock.picking_type_out").id,
+                "move_lines": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product_bolt_kit.id,
+                            "product_uom": self.product_bolt_kit.uom_id.id,
+                            "product_uom_qty": 1.0,
+                            "name": "test_move_1",
+                            "location_id": self.stock_location.id,
+                            "location_dest_id": self.customer_location.id,
+                            "picking_type_id": self.env.ref(
+                                "stock.picking_type_out"
+                            ).id,
+                        },
+                    ),
+                ],
+            }
+        )
+
+        picking_id.action_confirm()
+        self.assertEqual(len(picking_id.move_lines), 1)
+        self.assertEqual(picking_id.move_lines.product_id, self.product_bolta)

--- a/product_commingle_sale_stock/README.rst
+++ b/product_commingle_sale_stock/README.rst
@@ -1,0 +1,7 @@
+============================
+product_commingle_sale_stock
+============================
+
+Glue module between product_commingle_stock and sale_stock to provide warnings
+on sale orders when a commingled stock item may split.
+

--- a/product_commingle_sale_stock/__init__.py
+++ b/product_commingle_sale_stock/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/product_commingle_sale_stock/__manifest__.py
+++ b/product_commingle_sale_stock/__manifest__.py
@@ -1,0 +1,13 @@
+{
+    "name": "product_commingle_sale_stock",
+    "summary": "Integrates product_commingle and sale_stock",
+    "author": "Glo Networks",
+    "website": "https://github.com/OCA/stock-delivery",
+    "category": "Uncategorized",
+    "version": "15.0.1.0.0",
+    "depends": ["product_commingle_stock", "sale_stock"],
+    "auto_install": True,
+    "data": [],
+    "demo": [],
+    "license": "LGPL-3",
+}

--- a/product_commingle_sale_stock/models/__init__.py
+++ b/product_commingle_sale_stock/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale

--- a/product_commingle_sale_stock/models/sale.py
+++ b/product_commingle_sale_stock/models/sale.py
@@ -1,0 +1,49 @@
+from odoo import _, api, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    def _compute_qty_delivered(self):
+        res = super(SaleOrderLine, self)._compute_qty_delivered()
+        for order_line in self.filtered(lambda l: l.product_id.commingled_ok):
+            # TODO: we aren't supporting partial delivery of commingled products
+            # due to the complications of kits within commingled products, and
+            # how we go about dealing with those.
+            if all(m.state == "done" for m in order_line.move_ids):
+                order_line.qty_delivered = order_line.product_uom_qty
+            else:
+                order_line.qty_delivered = 0.0
+        return res
+
+    @api.onchange(
+        "product_id",
+        "product_uom_qty",
+        "product_uom",
+        "warehouse_id",
+    )
+    def _onchange_product_id_commingle(self):
+        if (
+            not self.product_id.commingled_ok
+            or not self.product_uom_qty
+            or not self.product_uom
+        ):
+            return
+
+        quantity = self.product_uom._compute_quantity(
+            self.product_uom_qty,
+            self.product_id.uom_id,
+        )
+
+        lines = self.product_id._explode_commingled(
+            quantity,
+            self.order_id.warehouse_id.lot_stock_id,
+        )
+
+        if len(lines) > 1:
+            return {
+                "warning": {
+                    "title": "Warning",
+                    "message": _("This product will split into %s lines") % len(lines),
+                }
+            }

--- a/product_commingle_sale_stock/tests/__init__.py
+++ b/product_commingle_sale_stock/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_sale

--- a/product_commingle_sale_stock/tests/test_sale.py
+++ b/product_commingle_sale_stock/tests/test_sale.py
@@ -1,0 +1,71 @@
+from odoo.tests import tagged
+
+from odoo.addons.product_commingle.tests.common import CommonCommingleCase
+
+
+@tagged("post_install", "-at_install")
+class TestSale(CommonCommingleCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.product_bolta.type = "product"
+        cls.product_boltb.type = "product"
+        cls.product_bolt_equiv.type = "product"
+        cls.product_bolt_equiv.commingled_policy = "strict"
+
+        cls.stock_location = cls.env.ref("stock.stock_location_stock")
+
+        cls.env["stock.quant"]._update_available_quantity(
+            cls.product_boltb, cls.stock_location, 10
+        )
+
+        cls.env["stock.quant"]._update_available_quantity(
+            cls.product_bolta, cls.stock_location, 5
+        )
+
+        cls.partner = cls.env["res.partner"].create(
+            {
+                "name": "Test partner",
+            }
+        )
+
+    def test_commingled_no_split(self):
+        sale_id = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product_bolt_equiv.id,
+                            "product_uom_qty": 1,
+                        },
+                    )
+                ],
+            }
+        )
+
+        res = sale_id.order_line._onchange_product_id_commingle()
+        self.assertFalse(res, "there should not be a warning when there is no split")
+
+    def test_commingled_split(self):
+        sale_id = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product_bolt_equiv.id,
+                            "product_uom_qty": 11,
+                        },
+                    )
+                ],
+            }
+        )
+
+        res = sale_id.order_line._onchange_product_id_commingle()
+        self.assertTrue(res, "there should be a warning when there is a split")

--- a/product_commingle_stock/README.rst
+++ b/product_commingle_stock/README.rst
@@ -1,0 +1,7 @@
+=======================
+product_commingle_stock
+=======================
+
+Integrates `product_commingle` and `stock`, ensuring that commingled stock on a
+`stock.move` is replaced with the relevant `product.commingle` stock.
+

--- a/product_commingle_stock/__init__.py
+++ b/product_commingle_stock/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/product_commingle_stock/__manifest__.py
+++ b/product_commingle_stock/__manifest__.py
@@ -1,0 +1,17 @@
+{
+    "name": "product_commingle_stock",
+    "summary": """product_commingle <-> stock glue module""",
+    "author": "Glo Networks",
+    "website": "https://github.com/OCA/stock-delivery",
+    "category": "Uncategorized",
+    "version": "15.0.1.0.0",
+    "depends": ["product_commingle", "stock"],
+    "auto_install": True,
+    "data": [
+        "security/ir.model.access.csv",
+        "views/stock_picking.xml",
+        "views/product_template.xml",
+        "views/product_commingled.xml",
+    ],
+    "license": "AGPL-3",
+}

--- a/product_commingle_stock/models/__init__.py
+++ b/product_commingle_stock/models/__init__.py
@@ -1,0 +1,3 @@
+from . import product
+from . import stock_move
+from . import stock_picking

--- a/product_commingle_stock/models/product.py
+++ b/product_commingle_stock/models/product.py
@@ -1,0 +1,166 @@
+from odoo import _, fields, models
+from odoo.exceptions import UserError
+from odoo.tools import float_round
+
+
+class ProductCommingled(models.Model):
+    _inherit = "product.commingled"
+
+    qty_available = fields.Float(related="product_id.qty_available")
+    virtual_available = fields.Float(related="product_id.virtual_available")
+    free_qty = fields.Float(related="product_id.free_qty")
+    incoming_qty = fields.Float(related="product_id.incoming_qty")
+    outgoing_qty = fields.Float(related="product_id.outgoing_qty")
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    commingled_policy = fields.Selection(
+        [
+            ("deplete", "Prioritise Depleting Stock"),
+            ("strict", "Exact Sequence"),
+        ],
+        default="deplete",
+        required=True,
+    )
+    commingled_prefer_homogenous = fields.Boolean(default=True)
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    def _explode_commingled_needs(self, qty, location_id=None):
+        self.ensure_one()
+        if not self.commingled_ok:
+            raise UserError(_("Product is not commingled"))
+
+        if not self.commingled_ids:
+            raise UserError(
+                _("Product %s has no commingled products") % (self.display_name)
+            )
+
+        bom_lines = []
+
+        for current_line in self.commingled_ids:
+            line_quantity = qty
+            available_line_quantity = qty
+
+            if location_id:
+                # get the amount in stock at this location, in the product's
+                # default UoM, if we've been passed a location, otherwise we
+                # have to assume we have the full stock, since we have no way of
+                # checking...
+                available_line_quantity = current_line.product_id.with_context(
+                    location=location_id.id
+                ).free_qty
+
+            # convert it to our line UoM
+            available_line_quantity = current_line.product_id.uom_id._compute_quantity(
+                available_line_quantity, self.uom_id
+            )
+
+            bom_lines.append(
+                (
+                    current_line,
+                    {
+                        "available_quantity": available_line_quantity,
+                        "needed_quantity": line_quantity,
+                    },
+                )
+            )
+
+        return bom_lines
+
+    def _explode_commingled_sorted(self, bom_needs):
+        self.ensure_one()
+
+        if self.commingled_policy == "strict":
+            bom_needs.sort(key=lambda x: x[0].sequence)
+
+        if self.commingled_policy == "deplete":
+            bom_needs.sort(key=lambda n: n[1]["available_quantity"])
+
+        return bom_needs
+
+    def _explode_commingled(self, quantity, location_id=None):
+        self.ensure_one()
+
+        bom_needs = self._explode_commingled_needs(quantity, location_id)
+
+        if not bom_needs:
+            raise UserError(_("No commingled products found!"))
+
+        # used later
+        highest_bom_needs = bom_needs[:1]
+
+        # sort the bom_needs by the policy
+        bom_needs = self._explode_commingled_sorted(bom_needs)
+
+        if self.commingled_prefer_homogenous:
+            # Can we completely fulfill an order with a single item? If so, prefer
+            # that.
+            complete_products = list(
+                filter(
+                    lambda line_data: line_data[1]["available_quantity"]
+                    >= line_data[1]["needed_quantity"],
+                    bom_needs,
+                )
+            )
+
+            if complete_products:
+                bom_line, line_data = next(iter(complete_products))
+                return [
+                    (
+                        bom_line,
+                        {
+                            "qty": line_data["needed_quantity"],
+                            "uom_qty": line_data["needed_quantity"],
+                        },
+                    )
+                ]
+
+        # Can't get a complete item, use the highest priority (top of the
+        # list), take as much as we can and then continue.
+        return_lines = []
+        quantity_left = quantity
+
+        for bom_line, line_data in bom_needs:
+            if quantity_left <= 0:
+                break
+
+            qty = min(line_data["available_quantity"], quantity_left)
+
+            if qty > 0:
+                quantity_left -= qty
+
+                return_lines.append(
+                    (
+                        bom_line,
+                        {
+                            "qty": qty,
+                            "uom_qty": qty,
+                        },
+                    )
+                )
+
+        # If we've got any left, take it from the highest priority
+        if quantity_left > 0:
+            bom_line, line_data = highest_bom_needs[0]
+
+            # round up any halves or odd numbers we get
+            return_lines.append(
+                (
+                    bom_line,
+                    {
+                        "qty": float_round(
+                            quantity_left,
+                            precision_rounding=bom_line.product_id.uom_id.rounding,
+                            rounding_method="UP",
+                        ),
+                        "uom_qty": quantity_left,
+                    },
+                )
+            )
+
+        return return_lines

--- a/product_commingle_stock/models/stock_move.py
+++ b/product_commingle_stock/models/stock_move.py
@@ -1,0 +1,102 @@
+from odoo import api, fields, models
+from odoo.tools import OrderedSet
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    commingled_original_product_id = fields.Many2one(
+        "product.product",
+        "Commingled Product",
+    )
+
+    @api.model
+    def _prepare_merge_moves_distinct_fields(self):
+        distinct_fields = super()._prepare_merge_moves_distinct_fields()
+        distinct_fields.append("commingled_original_product_id")
+        return distinct_fields
+
+    @api.model
+    def _prepare_merge_move_sort_method(self, move):
+        keys_sorted = super()._prepare_merge_move_sort_method(move)
+        keys_sorted.append(move.commingled_original_product_id.id)
+        return keys_sorted
+
+    def _action_confirm(self, merge=True, merge_into=False):
+        moves = self._action_commingled()
+
+        return super(StockMove, moves)._action_confirm(
+            merge=merge, merge_into=merge_into
+        )
+
+    def _skip_action_commingled(self):
+        self.ensure_one()
+        return not self.product_id.commingled_ok or not self.picking_type_id
+
+    def _action_commingled(self):
+        # Explodes commingled stock
+        #
+        # In order to explode a move, we must have a picking_type_id on that
+        # move because otherwise the move won't be assigned to a picking and it
+        # would be weird to explode a move into several if they aren't
+        # all grouped in the same picking.
+
+        moves_ids_to_return = OrderedSet()
+        moves_ids_to_unlink = OrderedSet()
+        equiv_moves_vals_list = []
+        for move in self:
+            if move._skip_action_commingled():
+                moves_ids_to_return.add(move.id)
+                continue
+
+            lines = move.product_id._explode_commingled(
+                move.product_uom_qty,
+                move.location_id,
+            )
+            for bom_line, line_data in lines:
+                qty_done = 0
+                if move.picking_id.immediate_transfer:
+                    qty_done = line_data.get("qty")
+
+                equiv_moves_vals_list += move._generate_move_commingled(
+                    bom_line, line_data, qty_done
+                )
+            # delete the move with original product which is not relevant anymore
+            moves_ids_to_unlink.add(move.id)
+
+        self.env["stock.move"].browse(moves_ids_to_unlink).sudo().unlink()
+        if equiv_moves_vals_list:
+            equivalent_moves = self.env["stock.move"].create(equiv_moves_vals_list)
+            equivalent_moves._adjust_procure_method()
+            # support commingled within commingled
+            moves_ids_to_return |= equivalent_moves._action_commingled().ids
+        return self.env["stock.move"].browse(moves_ids_to_return)
+
+    def _prepare_commingled_move_values(self, bom_line, line_data, quantity_done):
+        return {
+            "picking_id": self.picking_id.id if self.picking_id else False,
+            "product_id": bom_line.product_id.id,
+            "product_uom": bom_line.product_id.uom_id.id,
+            "product_uom_qty": line_data.get("qty"),
+            "state": "draft",
+            "name": self.name,
+            "quantity_done": quantity_done,
+            "picking_type_id": self.picking_type_id.id,
+            "commingled_original_product_id": (
+                self.commingled_original_product_id
+                if self.commingled_original_product_id.id
+                else self.product_id.id
+            ),
+        }
+
+    def _generate_move_commingled(self, bom_line, line_data, quantity_done=None):
+        vals = []
+        if bom_line.product_id.type in ["product", "consu"]:
+            vals = self.copy_data(
+                default=self._prepare_commingled_move_values(
+                    bom_line, line_data, quantity_done
+                )
+            )
+            if self.state == "assigned":
+                vals["state"] = "assigned"
+        return vals

--- a/product_commingle_stock/models/stock_picking.py
+++ b/product_commingle_stock/models/stock_picking.py
@@ -1,0 +1,14 @@
+from odoo import api, fields, models
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    has_commingled = fields.Boolean(compute="_compute_has_commingled")
+
+    @api.depends("move_lines")
+    def _compute_has_commingled(self):
+        for picking in self:
+            picking.has_commingled = any(
+                picking.move_lines.mapped("commingled_original_product_id")
+            )

--- a/product_commingle_stock/security/ir.model.access.csv
+++ b/product_commingle_stock/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_product_commingled_stock_manager,access_product_commingled_stock_manager,product_commingle.model_product_commingled,stock.group_stock_manager,1,1,1,1

--- a/product_commingle_stock/tests/__init__.py
+++ b/product_commingle_stock/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_stock

--- a/product_commingle_stock/tests/test_stock.py
+++ b/product_commingle_stock/tests/test_stock.py
@@ -1,0 +1,264 @@
+from odoo.tests import tagged
+
+from odoo.addons.product_commingle.tests.common import CommonCommingleCase
+
+
+@tagged("post_install", "-at_install")
+class TestStock(CommonCommingleCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.product_bolta.type = "product"
+        cls.product_boltb.type = "product"
+        cls.product_bolt_equiv.type = "product"
+        cls.product_bolt_equiv.commingled_policy = "strict"
+
+        cls.partner_id = cls.env["res.partner"].create({"name": "Partner A"})
+        cls.stock_location = cls.env.ref("stock.stock_location_stock")
+        cls.customer_location = cls.env.ref("stock.stock_location_customers")
+
+    def test_strict_default(self):
+        picking_id = self.env["stock.picking"].create(
+            {
+                "location_id": self.stock_location.id,
+                "location_dest_id": self.customer_location.id,
+                "picking_type_id": self.env.ref("stock.picking_type_out").id,
+                "move_lines": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product_bolt_equiv.id,
+                            "product_uom": self.product_bolt_equiv.uom_id.id,
+                            "product_uom_qty": 1.0,
+                            "name": "test_move_1",
+                            "location_id": self.stock_location.id,
+                            "location_dest_id": self.customer_location.id,
+                            "picking_type_id": self.env.ref(
+                                "stock.picking_type_out"
+                            ).id,
+                        },
+                    ),
+                ],
+            }
+        )
+
+        picking_id.action_confirm()
+        self.assertEqual(len(picking_id.move_lines), 1)
+        self.assertEqual(picking_id.move_lines.product_id, self.product_bolta)
+
+    def test_strict_reordered(self):
+        self.product_bolt_equiv.commingled_ids.filtered(
+            lambda r: r.product_id == self.product_bolta
+        ).write({"sequence": 10})
+        self.product_bolt_equiv.invalidate_cache()
+
+        picking_id = self.env["stock.picking"].create(
+            {
+                "location_id": self.stock_location.id,
+                "location_dest_id": self.customer_location.id,
+                "picking_type_id": self.env.ref("stock.picking_type_out").id,
+                "move_lines": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product_bolt_equiv.id,
+                            "product_uom": self.product_bolt_equiv.uom_id.id,
+                            "product_uom_qty": 1.0,
+                            "name": "test_move_1",
+                            "location_id": self.stock_location.id,
+                            "location_dest_id": self.customer_location.id,
+                            "picking_type_id": self.env.ref(
+                                "stock.picking_type_out"
+                            ).id,
+                        },
+                    ),
+                ],
+            }
+        )
+
+        picking_id.action_confirm()
+        self.assertEqual(len(picking_id.move_lines), 1)
+        self.assertEqual(picking_id.move_lines.product_id, self.product_boltb)
+
+    def test_deplete(self):
+        self.product_bolt_equiv.write({"commingled_policy": "deplete"})
+        self.product_bolt_equiv.invalidate_cache()
+
+        self.env["stock.quant"]._update_available_quantity(
+            self.product_boltb, self.stock_location, 100
+        )
+
+        self.env["stock.quant"]._update_available_quantity(
+            self.product_bolta, self.stock_location, 500
+        )
+
+        self.product_bolt_equiv.invalidate_cache()
+
+        picking_id = self.env["stock.picking"].create(
+            {
+                "location_id": self.stock_location.id,
+                "location_dest_id": self.customer_location.id,
+                "picking_type_id": self.env.ref("stock.picking_type_out").id,
+                "move_lines": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product_bolt_equiv.id,
+                            "product_uom": self.product_bolt_equiv.uom_id.id,
+                            "product_uom_qty": 1.0,
+                            "name": "test_move_1",
+                            "location_id": self.stock_location.id,
+                            "location_dest_id": self.customer_location.id,
+                            "picking_type_id": self.env.ref(
+                                "stock.picking_type_out"
+                            ).id,
+                        },
+                    ),
+                ],
+            }
+        )
+
+        picking_id.action_confirm()
+        self.assertEqual(len(picking_id.move_lines), 1)
+        self.assertEqual(picking_id.move_lines.product_id, self.product_boltb)
+
+    def test_deplete_prefer_homogenous(self):
+        self.product_bolt_equiv.write(
+            {
+                "commingled_policy": "deplete",
+                "commingled_prefer_homogenous": True,
+            }
+        )
+        self.product_bolt_equiv.invalidate_cache()
+
+        self.env["stock.quant"]._update_available_quantity(
+            self.product_boltb, self.stock_location, 100
+        )
+
+        self.env["stock.quant"]._update_available_quantity(
+            self.product_bolta, self.stock_location, 500
+        )
+
+        self.product_bolt_equiv.invalidate_cache()
+
+        picking_id = self.env["stock.picking"].create(
+            {
+                "location_id": self.stock_location.id,
+                "location_dest_id": self.customer_location.id,
+                "picking_type_id": self.env.ref("stock.picking_type_out").id,
+                "move_lines": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product_bolt_equiv.id,
+                            "product_uom": self.product_bolt_equiv.uom_id.id,
+                            "product_uom_qty": 102,
+                            "name": "test_move_1",
+                            "location_id": self.stock_location.id,
+                            "location_dest_id": self.customer_location.id,
+                            "picking_type_id": self.env.ref(
+                                "stock.picking_type_out"
+                            ).id,
+                        },
+                    ),
+                ],
+            }
+        )
+
+        picking_id.action_confirm()
+        self.assertEqual(len(picking_id.move_lines), 1)
+        self.assertEqual(picking_id.move_lines.product_id, self.product_bolta)
+
+    def test_deplete_no_prefer_homogenous(self):
+        self.product_bolt_equiv.write(
+            {
+                "commingled_policy": "deplete",
+                "commingled_prefer_homogenous": False,
+            }
+        )
+        self.product_bolt_equiv.invalidate_cache()
+
+        self.env["stock.quant"]._update_available_quantity(
+            self.product_boltb, self.stock_location, 100
+        )
+
+        self.env["stock.quant"]._update_available_quantity(
+            self.product_bolta, self.stock_location, 500
+        )
+
+        self.product_bolt_equiv.invalidate_cache()
+
+        picking_id = self.env["stock.picking"].create(
+            {
+                "location_id": self.stock_location.id,
+                "location_dest_id": self.customer_location.id,
+                "picking_type_id": self.env.ref("stock.picking_type_out").id,
+                "move_lines": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product_bolt_equiv.id,
+                            "product_uom": self.product_bolt_equiv.uom_id.id,
+                            "product_uom_qty": 102,
+                            "name": "test_move_1",
+                            "location_id": self.stock_location.id,
+                            "location_dest_id": self.customer_location.id,
+                            "picking_type_id": self.env.ref(
+                                "stock.picking_type_out"
+                            ).id,
+                        },
+                    ),
+                ],
+            }
+        )
+
+        picking_id.action_confirm()
+        self.assertEqual(len(picking_id.move_lines), 2)
+
+    def test_deplete_split(self):
+        self.product_bolt_equiv.write({"commingled_policy": "deplete"})
+        self.product_bolt_equiv.invalidate_cache()
+
+        self.env["stock.quant"]._update_available_quantity(
+            self.product_boltb, self.stock_location, 100
+        )
+
+        self.env["stock.quant"]._update_available_quantity(
+            self.product_bolta, self.stock_location, 100
+        )
+
+        self.product_bolt_equiv.invalidate_cache()
+
+        picking_id = self.env["stock.picking"].create(
+            {
+                "location_id": self.stock_location.id,
+                "location_dest_id": self.customer_location.id,
+                "picking_type_id": self.env.ref("stock.picking_type_out").id,
+                "move_lines": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product_bolt_equiv.id,
+                            "product_uom": self.product_bolt_equiv.uom_id.id,
+                            "product_uom_qty": 102,
+                            "name": "test_move_1",
+                            "location_id": self.stock_location.id,
+                            "location_dest_id": self.customer_location.id,
+                            "picking_type_id": self.env.ref(
+                                "stock.picking_type_out"
+                            ).id,
+                        },
+                    ),
+                ],
+            }
+        )
+
+        picking_id.action_confirm()
+        self.assertEqual(len(picking_id.move_lines), 2)

--- a/product_commingle_stock/views/product_commingled.xml
+++ b/product_commingle_stock/views/product_commingled.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<odoo>
+    <record id="view_product_commingled_tree" model="ir.ui.view">
+        <field name="name">view_product_commingled_tree</field>
+        <field name="model">product.commingled</field>
+        <field name="inherit_id" ref="product_commingle.view_product_commingled_tree" />
+        <field name="arch" type="xml">
+            <xpath expr="//tree" position="inside">
+                <field name="free_qty" />
+                <field name="virtual_available" />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/product_commingle_stock/views/product_template.xml
+++ b/product_commingle_stock/views/product_template.xml
@@ -1,0 +1,21 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<odoo>
+    <record id="product_template_form_view" model="ir.ui.view">
+        <field name="name">product_template_form_view</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view" />
+        <field name="arch" type="xml">
+            <xpath expr="//notebook/page[@name='page_commingled']" position="inside">
+                <group>
+                    <group>
+                        <field name="commingled_policy" string="Usage Policy" />
+                        <field
+                            name="commingled_prefer_homogenous"
+                            string="Prefer Homogenous"
+                        />
+                    </group>
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/product_commingle_stock/views/stock_picking.xml
+++ b/product_commingle_stock/views/stock_picking.xml
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<odoo>
+    <record id="view_picking_form" model="ir.ui.view">
+        <field name="name">view_picking_form</field>
+        <field name="model">stock.picking</field>
+        <field name="inherit_id" ref="stock.view_picking_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='use_create_lots']" position="after">
+                <field name="has_commingled" invisible="1" />
+            </xpath>
+            <xpath expr="//field[@name='description_picking']" position="after">
+                <field
+                    name="commingled_original_product_id"
+                    optional="show"
+                    attrs="{'column_invisible': [('parent.has_commingled', '=', False)]}"
+                />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/product_commingle_stock_available/README.rst
+++ b/product_commingle_stock_available/README.rst
@@ -1,0 +1,6 @@
+=================================
+product_commingle_stock_available
+=================================
+
+Glue module between product_commingle_stock and OCA/stock_available (and stock_available_mrp).
+

--- a/product_commingle_stock_available/__init__.py
+++ b/product_commingle_stock_available/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/product_commingle_stock_available/__manifest__.py
+++ b/product_commingle_stock_available/__manifest__.py
@@ -1,0 +1,13 @@
+{
+    "name": "product_commingle_stock_available",
+    "summary": """product_commingle_stock <-> OCA/stock_available glue module""",
+    "author": "Glo Networks",
+    "website": "https://github.com/OCA/stock-delivery",
+    "category": "Uncategorized",
+    "version": "15.0.1.0.0",
+    "depends": ["product_commingle_stock", "stock_available"],
+    "data": [],
+    "demo": [],
+    "auto_install": True,
+    "license": "AGPL-3",
+}

--- a/product_commingle_stock_available/models/__init__.py
+++ b/product_commingle_stock_available/models/__init__.py
@@ -1,0 +1,1 @@
+from . import product

--- a/product_commingle_stock_available/models/product.py
+++ b/product_commingle_stock_available/models/product.py
@@ -1,0 +1,51 @@
+from odoo import api, models
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    @api.depends("commingled_ids")
+    def _compute_available_quantities(self):
+        return super()._compute_available_quantities()
+
+    def _compute_available_quantities_dict(self):
+        res, stock_dict = super()._compute_available_quantities_dict()
+        icp = self.env["ir.config_parameter"]
+        based_on = icp.sudo().get_param("stock_available_mrp_based_on", "potential_qty")
+
+        todo = self.filtered(lambda p: p.commingled_ok)
+
+        if not todo:
+            return res, stock_dict
+
+        component_ids = self.env["product.product"]
+        while todo:
+            component_ids = todo.mapped("commingled_ids.product_id").filtered(
+                lambda p: not p.commingled_ok
+            )
+            todo = component_ids.filtered(lambda p: p.commingled_ok)
+
+        (
+            commingled_res,
+            commingled_stock_dict,
+        ) = component_ids._compute_available_quantities_dict()
+        stock_dict = {**stock_dict, **commingled_stock_dict}
+        res = {**res, **commingled_res}
+
+        for product_id in self.filtered(lambda p: p.commingled_ok and p.commingled_ids):
+            # TODO: Create an explode-all-at-once method?
+            needs = product_id._explode_commingled_needs(1)
+
+            potential = []
+
+            for line, _need in needs:
+                fallback = stock_dict[line.product_id.id]["qty_available"]
+                potential.append(stock_dict[line.product_id.id].get(based_on, fallback))
+
+            potential = sum(potential)
+
+            res[product_id.id]["qty_available"] = potential
+            res[product_id.id]["potential_qty"] = potential
+            res[product_id.id]["immediately_usable_qty"] = potential
+
+        return res, stock_dict

--- a/product_commingle_stock_available/tests/__init__.py
+++ b/product_commingle_stock_available/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_stock

--- a/product_commingle_stock_available/tests/test_stock.py
+++ b/product_commingle_stock_available/tests/test_stock.py
@@ -1,0 +1,33 @@
+from odoo.tests import tagged
+
+from odoo.addons.product_commingle.tests.common import CommonCommingleCase
+
+
+@tagged("post_install", "-at_install")
+class TestStock(CommonCommingleCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.product_bolta.type = "product"
+        cls.product_boltb.type = "product"
+        cls.product_bolt_equiv.type = "product"
+        cls.product_bolt_equiv.commingled_policy = "strict"
+
+        cls.stock_location = cls.env.ref("stock.stock_location_stock")
+
+    def test_commingled_no_stock(self):
+        self.assertEqual(self.product_bolt_equiv.potential_qty, 0)
+        self.assertEqual(self.product_bolt_equiv.immediately_usable_qty, 0)
+
+    def test_commingled_partial_stock(self):
+        self.env["stock.quant"]._update_available_quantity(
+            self.product_boltb, self.stock_location, 100
+        )
+
+        self.env["stock.quant"]._update_available_quantity(
+            self.product_bolta, self.stock_location, 500
+        )
+
+        self.assertEqual(self.product_bolt_equiv.potential_qty, 600)
+        self.assertEqual(self.product_bolt_equiv.immediately_usable_qty, 600)


### PR DESCRIPTION
Adds product_commingle and friends.

This module is built to replace mrp_phantom_equiv under 14+ where the BoM explosion makes this module now impractical.

Improvements:

* No longer requires MRP - MRP is optional through product_commingle_mrp
* No longer requires stock - Stock is now optional through product_commingle_stock (although why you'd want to install it without is beyond me)
* No longer requires sale - Sale is now optional through product_commingle_sale
* Integrates with OCA/stock_available and OCA/stock_available_mrp through product_commingle_stock_available