### PR TITLE
feat(product_commingle,product_commingle_stock): allow commingled_ok …

### DIFF
--- a/product_commingle/__manifest__.py
+++ b/product_commingle/__manifest__.py
@@ -4,7 +4,7 @@
     "author": "Glo Networks",
     "website": "https://github.com/GlodoUK/stock-delivery",
     "category": "Uncategorized",
-    "version": "15.0.1.0.0",
+    "version": "15.0.1.1.0",
     "depends": ["product"],
     "data": [
         "security/ir.model.access.csv",

--- a/product_commingle/migrations/15.0.1.1.0/pre-migration.py
+++ b/product_commingle/migrations/15.0.1.1.0/pre-migration.py
@@ -1,0 +1,32 @@
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    if openupgrade.column_exists(env.cr, "product_product", "commingled_ok"):
+        return
+
+    openupgrade.logged_query(
+        env.cr,
+        """
+        ALTER TABLE product_product
+        ADD COLUMN commingled_ok boolean
+        """,
+    )
+
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE
+            product_product
+        SET commingled_ok = true
+        WHERE id IN (
+            SELECT
+                p.id
+            FROM product_product AS p
+            INNER JOIN product_template AS t on t.id = p.product_tmpl_id
+            WHERE
+                t.commingled_ok is true
+        )
+        """,
+    )

--- a/product_commingle/models/product_product.py
+++ b/product_commingle/models/product_product.py
@@ -1,8 +1,13 @@
-from odoo import fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class ProductProduct(models.Model):
     _inherit = "product.product"
+
+    commingled_ok = fields.Boolean(
+        "Is Commingled?",
+    )
 
     commingled_ids = fields.One2many(
         "product.commingled",
@@ -16,3 +21,28 @@ class ProductProduct(models.Model):
         "product_id",
         copy=False,
     )
+
+    @api.constrains("company_id", "product_variant_ids")
+    def _check_commingled_company(self):
+        # Ensure that the commingled products are all in the same company
+        for record in self:
+            for line in record.commingled_ids:
+                if (
+                    line.product_id.company_id and record.company_id
+                ) and line.product_id.company_id != record.company_id:
+                    raise ValidationError(
+                        _(
+                            "Commingled products must be in the company same as"
+                            " the parent product"
+                        )
+                    )
+            for line in record.used_in_commingled_ids:
+                if (
+                    line.product_id.company_id and record.company_id
+                ) and line.parent_product_id.company_id != record.company_id:
+                    raise ValidationError(
+                        _(
+                            "Commingled products must be in the company same as"
+                            " the parent product"
+                        )
+                    )

--- a/product_commingle/models/product_template.py
+++ b/product_commingle/models/product_template.py
@@ -1,5 +1,4 @@
-from odoo import _, api, fields, models
-from odoo.exceptions import ValidationError
+from odoo import api, fields, models
 
 
 class ProductTemplate(models.Model):
@@ -7,15 +6,31 @@ class ProductTemplate(models.Model):
 
     commingled_ok = fields.Boolean(
         "Is Commingled?",
+        compute="_compute_commingled_ok",
+        inverse="_inverse_commingled_ok",
     )
+
     commingled_ids = fields.One2many(
         "product.commingled",
         compute="_compute_commingled",
         inverse="_inverse_commingled",
     )
+
     used_in_commingled_ids = fields.One2many(
         related="product_variant_ids.used_in_commingled_ids",
     )
+
+    @api.depends("product_variant_ids.commingled_ok")
+    def _compute_commingled_ok(self):
+        for record in self:
+            record.commingled_ok = all(
+                v.commingled_ok for v in record.product_variant_ids
+            )
+
+    def _inverse_commingled_ok(self):
+        for p in self:
+            if len(p.product_variant_ids) == 1:
+                p.product_variant_ids.commingled_ok = p.commingled_ok
 
     @api.depends("product_variant_ids", "product_variant_ids.commingled_ids")
     def _compute_commingled(self):
@@ -29,28 +44,3 @@ class ProductTemplate(models.Model):
         for p in self:
             if len(p.product_variant_ids) == 1:
                 p.product_variant_ids.commingled_ids = p.commingled_ids
-
-    @api.constrains("company_id", "product_variant_ids")
-    def _check_commingled_company(self):
-        # Ensure that the commingled products are all in the same company
-        for record in self:
-            for line in record.commingled_ids:
-                if (
-                    line.product_id.company_id and record.company_id
-                ) and line.product_id.company_id != record.company_id:
-                    raise ValidationError(
-                        _(
-                            "Commingled products must be in the company same as"
-                            " the parent product"
-                        )
-                    )
-            for line in record.used_in_commingled_ids:
-                if (
-                    line.product_id.company_id and record.company_id
-                ) and line.parent_product_id.company_id != record.company_id:
-                    raise ValidationError(
-                        _(
-                            "Commingled products must be in the company same as"
-                            " the parent product"
-                        )
-                    )

--- a/product_commingle/views/product_template.xml
+++ b/product_commingle/views/product_template.xml
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='utf-8' ?>
 <odoo>
-    <record id="product_template_form_view" model="ir.ui.view">
-        <field name="name">product_template_form_view</field>
-        <field name="model">product.template</field>
-        <field name="inherit_id" ref="product.product_template_form_view" />
+    <record id="product_normal_form_view" model="ir.ui.view">
+        <field name="name">product_normal_form_view</field>
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="product.product_normal_form_view" />
         <field name="arch" type="xml">
             <xpath expr="//div[@name='options']" position="inside">
                 <div>
@@ -12,11 +12,7 @@
                 </div>
             </xpath>
             <xpath expr="//notebook/page[@name='general_information']" position="after">
-                <page
-                    name="page_commingled"
-                    string="Commingled"
-                    attrs="{'invisible': [('commingled_ok', '=', False)]}"
-                >
+                <page name="page_commingled" string="Commingled">
                    <field name="commingled_ids" />
                 </page>
             </xpath>
@@ -27,11 +23,42 @@
         <field name="model">product.template</field>
         <field name="inherit_id" ref="product.product_template_only_form_view" />
         <field name="arch" type="xml">
-            <page name="page_commingled" position="attributes">
-                <attribute
-                    name="attrs"
-                >{'invisible': ['|', ('product_variant_count', '&gt;', 1), ('commingled_ok', '=', False)]}</attribute>
-            </page>
+            <xpath expr="//div[@name='options']" position="inside">
+                <div>
+                    <field
+                        name="commingled_ok"
+                        attrs="{'readonly': [('product_variant_count', '&gt;', 1)]}"
+                    />
+                    <label for="commingled_ok" />
+                </div>
+            </xpath>
+
+            <xpath expr="//notebook/page[@name='general_information']" position="after">
+                <page
+                    name="page_commingled"
+                    string="Commingled"
+                    attrs="{'invisible': ['|', ('product_variant_count', '&gt;', 1), ('commingled_ok', '=', False)]}"
+                >
+                   <field name="commingled_ids" />
+               </page>
+            </xpath>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="product_variant_easy_edit_view">
+        <field name="name">product_variant_easy_edit_view</field>
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="product.product_variant_easy_edit_view" />
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='codes']/.." position="inside">
+                <group>
+                    <field name="commingled_ok" />
+                    <field
+                        name="commingled_ids"
+                        attrs="{'invisible': [('commingled_ok', '=', False)]}"
+                    />
+                </group>
+            </xpath>
         </field>
     </record>
 </odoo>

--- a/product_commingle_stock/__manifest__.py
+++ b/product_commingle_stock/__manifest__.py
@@ -4,7 +4,7 @@
     "author": "Glo Networks",
     "website": "https://github.com/GlodoUK/stock-delivery",
     "category": "Uncategorized",
-    "version": "15.0.1.0.0",
+    "version": "15.0.1.2.0",
     "depends": ["product_commingle", "stock"],
     "auto_install": True,
     "data": [

--- a/product_commingle_stock/migrations/15.0.1.1.0/pre-migration.py
+++ b/product_commingle_stock/migrations/15.0.1.1.0/pre-migration.py
@@ -1,0 +1,8 @@
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.delete_records_safely_by_xml_id(
+        env, ["product_commingle_stock.product_template_form_view"]
+    )

--- a/product_commingle_stock/migrations/15.0.1.2.0/pre-migration.py
+++ b/product_commingle_stock/migrations/15.0.1.2.0/pre-migration.py
@@ -1,0 +1,31 @@
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    if not openupgrade.column_exists(
+        env.cr, "product_product", "commingled_policy"
+    ) and openupgrade.column_exists(env.cr, "product_template", "commingled_policy"):
+
+        openupgrade.logged_query(
+            env.cr,
+            """
+            ALTER TABLE product_product
+            ADD COLUMN commingled_policy varchar,
+            ADD COLUMN commingled_prefer_homogenous boolean
+            """,
+        )
+
+        openupgrade.logged_query(
+            env.cr,
+            """
+            UPDATE
+                product_product
+            SET
+                commingled_policy = product_template.commingled_policy,
+                commingled_prefer_homogenous = product_template.commingled_prefer_homogenous
+            FROM product_template
+            WHERE
+                product_template.id = product_product.product_tmpl_id
+            """,
+        )

--- a/product_commingle_stock/models/product.py
+++ b/product_commingle_stock/models/product.py
@@ -1,4 +1,4 @@
-from odoo import _, fields, models
+from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 from odoo.tools import float_round
 
@@ -13,22 +13,69 @@ class ProductCommingled(models.Model):
     outgoing_qty = fields.Float(related="product_id.outgoing_qty")
 
 
+COMMINGLED_POLICY = [
+    ("deplete", "Prioritise Depleting Stock"),
+    ("strict", "Exact Sequence"),
+]
+COMMINGLED_DEFAULT = "deplete"
+
+
 class ProductTemplate(models.Model):
     _inherit = "product.template"
 
     commingled_policy = fields.Selection(
-        [
-            ("deplete", "Prioritise Depleting Stock"),
-            ("strict", "Exact Sequence"),
-        ],
-        default="deplete",
+        COMMINGLED_POLICY,
+        default=COMMINGLED_DEFAULT,
         required=True,
+        compute="_compute_commingled_policy",
+        inverse="_inverse_commingled_policy",
     )
-    commingled_prefer_homogenous = fields.Boolean(default=True)
+    commingled_prefer_homogenous = fields.Boolean(
+        default=True,
+        compute="_compute_commingled_prefer_homogenous",
+        inverse="_inverse_commingled_prefer_homogenou",
+    )
+
+    @api.depends("product_variant_ids.commingled_policy")
+    def _compute_commingled_policy(self):
+        for record in self:
+            if len(record.product_variant_ids) == 1:
+                record.commingled_policy = record.product_variant_ids.commingled_policy
+            else:
+                record.commingled_policy = COMMINGLED_DEFAULT
+
+    def _inverse_commingled_policy(self):
+        for p in self:
+            if len(p.product_variant_ids) == 1:
+                p.product_variant_ids.commingled_policy = p.commingled_policy
+
+    @api.depends("product_variant_ids.commingled_prefer_homogenous")
+    def _compute_commingled_prefer_homogenous(self):
+        for record in self:
+            if len(record.product_variant_ids) == 1:
+                record.commingled_prefer_homogenous = (
+                    record.product_variant_ids.commingled_prefer_homogenous
+                )
+            else:
+                record.commingled_prefer_homogenous = True
+
+    def _inverse_commingled_prefer_homogenous(self):
+        for p in self:
+            if len(p.product_variant_ids) == 1:
+                p.product_variant_ids.commingled_prefer_homogenous = (
+                    p.commingled_prefer_homogenous
+                )
 
 
 class ProductProduct(models.Model):
     _inherit = "product.product"
+
+    commingled_policy = fields.Selection(
+        COMMINGLED_POLICY,
+        default=COMMINGLED_DEFAULT,
+        required=True,
+    )
+    commingled_prefer_homogenous = fields.Boolean(default=True)
 
     def _explode_commingled_needs(self, qty, location_id=None):
         self.ensure_one()

--- a/product_commingle_stock/views/product_template.xml
+++ b/product_commingle_stock/views/product_template.xml
@@ -1,9 +1,31 @@
 <?xml version='1.0' encoding='utf-8' ?>
 <odoo>
-    <record id="product_template_form_view" model="ir.ui.view">
+    <record id="product_normal_form_view2" model="ir.ui.view">
         <field name="name">product_template_form_view</field>
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="product_commingle.product_normal_form_view" />
+        <field name="arch" type="xml">
+            <xpath expr="//notebook/page[@name='page_commingled']" position="inside">
+                <group>
+                    <group>
+                        <field name="commingled_policy" string="Usage Policy" />
+                        <field
+                            name="commingled_prefer_homogenous"
+                            string="Prefer Homogenous"
+                        />
+                    </group>
+                </group>
+            </xpath>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="product_template_only_form_view2">
+        <field name="name">product_template_only_form_view</field>
         <field name="model">product.template</field>
-        <field name="inherit_id" ref="product.product_template_form_view" />
+        <field
+            name="inherit_id"
+            ref="product_commingle.product_template_only_form_view"
+        />
         <field name="arch" type="xml">
             <xpath expr="//notebook/page[@name='page_commingled']" position="inside">
                 <group>


### PR DESCRIPTION
…to be defined on the product.product, rather than always on the product.template, catering for product ranges where variants may be commingled or not independently

This is a partial fix for T4814.