### PR TITLE
Replace # with - in Sku for carriers that don't support #

### DIFF
--- a/delivery_parcelhub_whistl/models/delivery.py
+++ b/delivery_parcelhub_whistl/models/delivery.py
@@ -278,7 +278,7 @@ class DeliveryCarrier(models.Model):
                     product_list.append(
                         {
                             "Description": line.product_id.name,
-                            "Sku": line.product_id.default_code,
+                            "Sku": line.product_id.default_code.replace("#", "-"),
                             "OriginCountry": picking.location_id.company_id.country_id.code
                             or "GB",
                             "Quantity": str(int(line.quantity)),


### PR DESCRIPTION
Some carriers don't accept product SKUs with a # in them. Patch to replace them with - when sending

Fixes GH109229

Associated risk level low

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update