### PR TITLE
GH115206 - Split tracking job into batches

### DIFF
--- a/delivery_parcelhub_whistl/models/delivery.py
+++ b/delivery_parcelhub_whistl/models/delivery.py
@@ -551,8 +551,8 @@ class DeliveryCarrier(models.Model):
                 )
             picking.state = "cancel"
 
-    def whistl_tracking_state_update_scheduled(self):
-        pickings = self.env["stock.picking"].search(
+    def _whistl_get_waiting_pickings(self, limit=100):
+        return self.env["stock.picking"].search(
             [
                 ("carrier_id", "=", self.id),
                 ("state", "=", "done"),
@@ -565,12 +565,18 @@ class DeliveryCarrier(models.Model):
                 "|",
                 ("carrier_consignment_ref", "!=", False),
                 ("carrier_tracking_ref", "!=", False),
-            ]
+            ],
+            limit=limit,  # Added this to fix timeouts etc
         )
+
+    def whistl_tracking_state_update_scheduled(self, batch_size=100):
+        pickings = self._whistl_get_waiting_pickings(limit=batch_size)
         for picking in pickings:
             if picking.delivery_state in ["customer_delivered", "warehouse_delivered"]:
                 continue
             self.whistl_tracking_state_update(picking)
+        if self._whistl_get_waiting_pickings():
+            self.with_delay().whistl_tracking_state_update_scheduled()
 
     def whistl_tracking_state_update(self, picking):
         request_url = self._get_whistl_tracking_url(

--- a/delivery_parcelhub_whistl/models/delivery.py
+++ b/delivery_parcelhub_whistl/models/delivery.py
@@ -604,7 +604,19 @@ class DeliveryCarrier(models.Model):
                 ).format(status_code=response.status_code, message=message)
             )
 
-        tracking_response = ET.fromstring(response.content)
+        try:
+            tracking_response = ET.fromstring(response.content)
+        except Exception as e:
+            raise ValidationError(
+                _(
+                    "Failed to get tracking information for picking %(picking_name)s\n\n"
+                    "Response:\n%(response_content)s"
+                )
+                % {
+                    "picking_name": picking.name,
+                    "response_content": response.content,
+                }
+            ) from e
         events = tracking_response.findall(".//TrackingEvent")
 
         sorted_events = []


### PR DESCRIPTION
Status checks were timing out and causing errors because there are too many records to fix in the backlog. This will splitthe job into batches (100 records by default) to try to prevent this.

This is a PARTIAL fix as it appears there are still issues with certain responses coming back from Whistl that are casing the XML conversion to fail. An exception catch has been added to attempt to identify what is wrong with the response.

Fixes GH115206

Associated risk level low

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Suggested UAT/Review Steps

If applicable please list any steps that the end user may require to verify or test the new behaviour.

