### PR TITLE
exclude no variant attributes from simple variant wizard

### DIFF
--- a/product_simple_variant_builder/wizards/wizard_simple_create_variant.py
+++ b/product_simple_variant_builder/wizards/wizard_simple_create_variant.py
@@ -50,6 +50,9 @@ class WizardSimpleCreateVariant(models.TransientModel):
         if self.product_tmpl_id:
             lines = line_model.browse()
             pending_variants = self.product_tmpl_id.attribute_line_ids
+            pending_variants = pending_variants.filtered(
+                lambda tmpl_att_line: tmpl_att_line.attribute_id.display_type != "multi"
+            )
             for line_data in [
                 {
                     "attribute_id": attribute_line.attribute_id.id,
@@ -142,7 +145,9 @@ class WizardCreateVariantLine(models.TransientModel):
         required=False,
     )
     attribute_id = fields.Many2one(
-        comodel_name="product.attribute", string="Attribute", required=False
+        comodel_name="product.attribute",
+        string="Attribute",
+        required=False,
     )
     attribute_value_ids = fields.Many2many(
         comodel_name="product.attribute.value",


### PR DESCRIPTION
reason: attributes with detailed type set as multi are considered to have variant creation mode as "Never", hence no variants are created for them. This ensures variants products purchased are aligned with SOs.

without this fix, product variants including multi type attributes results in received stocks for POs not being consumable by SOs although configured product on SO shares matching attribute value options

**After Fix**
![After Fix - simple variant builder](https://github.com/user-attachments/assets/c93507bc-8713-47c7-a784-c80c7f0b4a03)

**Before Fix**
![Before Fix - simple variant builder](https://github.com/user-attachments/assets/59cf2eb6-033f-4bc8-9fe2-71789c781d15)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Suggested UAT/Review Steps

If applicable please list any steps that the end user may require to verify or test the new behaviour.

